### PR TITLE
Get rid of 'ambiguous definition' warnings in base/floatfuncs.jl

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -249,6 +249,10 @@ end
 for f in unary_functions
     ## @eval import Base.(f)
     eval(Expr(:toplevel, Expr(:import, :Base, f)))
+
+    # Define separate method to get rid of 'ambiguous definition' warnings in base/floatfuncs.jl
+    @eval ($f)(x::ModelType, arg::Integer) = mexpr(:call, ($f), _expr(x), arg)
+
     @eval ($f)(x::ModelType, args...) = mexpr(:call, ($f), _expr(x), map(_expr, args)...)
 end
 


### PR DESCRIPTION
Base library functions 'round', 'ceil', 'floor' and 'trunc' now can have second Integer argument (defined in base/floatfuncs.jl). This caused warnings about ambiguous definitions during loading of package Sims.

One warning still exists during loading Sims in recent Julia version. Are there any ideas how to resolve it?

```
julia> using Sims
Warning: New definition
    BranchHeatPort(Union(Unknown{UAngle},Number,RefUnknown{UAngle},MExpr,Abstrac
tArray{T,N}),Union(Unknown{UAngle},Number,RefUnknown{UAngle},MExpr,AbstractArray
{T,N}),Union(Unknown{UHeatPort},Number,RefUnknown{UHeatPort},MExpr,AbstractArray
{T,N}),Function,Any...) at D:\Documents and Settings\PGR\.julia\Sims\src\rotatio
nal.jl:57
is ambiguous with
    BranchHeatPort(Union(Unknown{UVoltage},Number,RefUnknown{UVoltage},MExpr,Abs
tractArray{T,N}),Union(Unknown{UVoltage},Number,RefUnknown{UVoltage},MExpr,Abstr
actArray{T,N}),Union(Unknown{UHeatPort},Number,RefUnknown{UHeatPort},MExpr,Abstr
actArray{T,N}),Function,Any...) at D:\Documents and Settings\PGR\.julia\Sims\src
\electrical.jl:26.
Make sure
    BranchHeatPort(Union(Number,MExpr,AbstractArray{T,N}),Union(Number,MExpr,Abs
tractArray{T,N}),Union(Unknown{UHeatPort},Number,RefUnknown{UHeatPort},MExpr,Abs
tractArray{T,N}),Function,Any...)
is defined first.

julia>
```
